### PR TITLE
Fix: Voucher checking false negatives and encoding issues

### DIFF
--- a/utils/Exporter.py
+++ b/utils/Exporter.py
@@ -23,12 +23,13 @@ class Exporter:
 
     def mark_vouchers_as_used(self, voucher_file_paths: list[str]):
         for voucher_file_path in voucher_file_paths:
-            self.add_voucher_to_used_list(voucher_file_path)
+            voucher_file_name = pathlib.Path(voucher_file_path).name
+            self.add_voucher_to_used_list(voucher_file_name)
             self.delete_voucher_file(voucher_file_path)
 
     def get_voucher_value_from_filename(self, voucher_file_path: str) -> int:
         try:
-            return int(voucher_file_path.split("_")[-1].split(".")[0].replace("£", "").strip())
+            return int(voucher_file_path.split("_")[-1].split(".")[0].strip())
         except ValueError:
             print(f"Error parsing voucher value from filename: {voucher_file_path}")
             return 0

--- a/utils/Scraper.py
+++ b/utils/Scraper.py
@@ -10,9 +10,9 @@ class Scraper:
         if not pathlib.Path(self.USED_VOUCHER_FILE).exists():
             return False
 
-        with open(self.USED_VOUCHER_FILE, "r") as file:
+        with open(self.USED_VOUCHER_FILE, "r", encoding="utf-8") as file:
             used_vouchers = file.readlines()
-        return voucher_file_name in [line.strip() for line in used_vouchers]
+        return pathlib.Path(voucher_file_name).name in [line.strip() for line in used_vouchers]
 
     def click_accept_cookies(self, page):
         try:
@@ -33,6 +33,7 @@ class Scraper:
     def get_voucher_text(self, voucher):
         voucher_code = voucher.query_selector("h3").inner_text()
         voucher_amount = voucher.query_selector("h4").inner_text().split()[-1]
+        voucher_amount = voucher_amount.replace("£", "").strip()
         return voucher_code, voucher_amount
 
     def get_voucher_file_name(self, voucher_code, voucher_amount):


### PR DESCRIPTION
## Problem:

Currently, the voucher validation system has two main issues that lead to false negatives (vouchers being incorrectly identified as unused):

- Mismatched File Paths: The mark_vouchers_as_used function stores the full file path (e.g., store/{file}.png) in used_vouchers.txt. However, the voucher checking logic only checks for the filename (e.g., {file}.png). This mismatch causes a voucher to be marked as used under one name but checked for under another, leading to a failure to recognize it as used.

- Encoding Errors: Filenames containing the '£' symbol can cause encoding mismatches, further contributing to incorrect validation results.

## Solution:

This pull request addresses both issues with the following changes:

- Amended mark_vouchers_as_used: The function now extracts only the filename from the path and stores it in used_vouchers.txt. This ensures consistency between how a voucher is marked as used and how it is checked, resolving the false negative issue.

- Removed '£' from Filenames: All filenames and entries in used_vouchers.txt have been updated to remove the '£' symbol, preventing potential encoding errors and ensuring robust file handling.

## Impact:

This fix ensures that the voucher validation system works as intended, correctly identifying and marking used vouchers. It resolves a significant bug that could lead to double-usage or incorrect voucher tracking.

**This issue may have side-effect on PR #10 (Created by @AlexTo1290 ) since the email feature must obtain the voucher value from somewhere.**

## Testing:

Manual end-to-end testing performed. No unit tests written.